### PR TITLE
Remove redundant ".zip" suffix of signed ZIPs

### DIFF
--- a/Extractor.bat
+++ b/Extractor.bat
@@ -506,7 +506,7 @@ cls
 
   cd sign_files
 
-java -jar signapk.jar testkey.x509.pem testkey.pk8 %filename% signed_%filename%.zip 
+java -jar signapk.jar testkey.x509.pem testkey.pk8 %filename% signed_%filename%
   del signapk.jar
   del testkey.x509.pem
   del testkey.pk8


### PR DESCRIPTION
When a ZIP file is being signed, the signed package will have an additional ".zip" suffix.
This change removes that additional file extension name.